### PR TITLE
screen recognizer 매크로 추가 (naver & red table)

### DIFF
--- a/html/naver_button.html
+++ b/html/naver_button.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>Page Title</title>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+button{
+background-color: green;
+width: 200px;
+height: 100px;
+}
+</style>
+<script>
+function clickRandom() {
+    var rand = Math.random();
+    if (rand < 0.5) {
+        window.location.href = "https://www.naver.com";
+    }else{
+	alert('문제!');
+    }
+}
+</script>
+</head>
+<body>
+
+<button onclick="clickRandom()">네이버 페이지로 이동</button>
+
+</body>
+</html>

--- a/html/red_table.html
+++ b/html/red_table.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+table, th, td {
+  border: 1px solid black;
+}
+td {
+  width: 150px;
+  height: 150px;
+  
+}
+</style>
+<script>
+function makeRedBG() {
+	
+    var rand = Math.random();
+    if (rand < 0.5) {
+        var table = document.getElementById('mytable');
+	var row = Math.ceil(Math.random() * 100) % 3;
+    	var column = Math.ceil(Math.random() * 100) % 3;
+        	console.log(row)
+        	console.log(column)    	
+
+        table.rows[row].cells[column].style.backgroundColor = "red";
+    }
+}
+window.onload = function() {
+  makeRedBG()
+}
+</script>
+</head>
+<body>
+
+<h2>Table With Border</h2>
+
+<table id="mytable">
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+
+</body>
+</html>

--- a/screen_recognition_red_table.ipynb
+++ b/screen_recognition_red_table.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyautogui as pag\n",
+    "from PIL import ImageGrab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#왼쪽 위 시작 position\n",
+    "start = pag.position()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#오른쪽 아래 끝 position\n",
+    "end = pag.position()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#새로고침 position\n",
+    "reload_pos = pag.position()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 화면 인식 매크로 : 메인 로직\n",
+    "red = (255, 0, 0)\n",
+    "is_red_appeared = False\n",
+    "\n",
+    "while True:\n",
+    "    screen = ImageGrab.grab() #화면 캡쳐\n",
+    "    for i in range(start[0], end[0]):\n",
+    "        for j in range(start[1], end[1]):\n",
+    "            rgb = screen.getpixel((i, j))\n",
+    "            if rgb == red:\n",
+    "                pag.click((i+15, j+15))\n",
+    "                is_red_appeared = True\n",
+    "                break\n",
+    "        if is_red_appeared:\n",
+    "            break\n",
+    "    if not is_red_appeared:\n",
+    "        # 새로고침\n",
+    "        pag.click(reload_pos)\n",
+    "    else:\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: 위의 화면 캡처 로직이 x와 y 에 대한 루프를 너무 많이 도는 것 같아서, 각 cell의 중간 position 만 탐색하는 로직으로 리팩토링을 했는데 잘 동작 안함.. 왜??\n",
+    "red = (255, 0, 0)\n",
+    "is_red_appeared = False\n",
+    "start = pag.position()\n",
+    "rows = 3\n",
+    "columns = 3\n",
+    "cellWidth = 150\n",
+    "\n",
+    "for time in range(3):\n",
+    "    screen = ImageGrab.grab()\n",
+    "    print(\"time: \", time)\n",
+    "    for x in range(rows):\n",
+    "        print(\"x: \", x)\n",
+    "        for y in range(columns):\n",
+    "            print(\"y: \", y)\n",
+    "            cellX = cellWidth * x + start.x\n",
+    "            cellY = cellWidth * y + start.y\n",
+    "            cellCenter = ((cellX + cellWidth/2), (cellY + cellWidth/2))\n",
+    "            print(cellCenter)\n",
+    "            rgb = screen.getpixel(cellCenter)\n",
+    "            if rgb == red:\n",
+    "                pag.click(cellCenter)\n",
+    "                is_red_appeared = True\n",
+    "                break\n",
+    "        if is_red_appeared:\n",
+    "            break\n",
+    "                \n",
+    "    if not is_red_appeared:\n",
+    "        # 새로고침\n",
+    "        # pag.hotkey(\"ctrl\", \"r\")\n",
+    "        pag.click(reload_pos)\n",
+    "    else:\n",
+    "        break"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/screen_recognizer_naver.ipynb
+++ b/screen_recognizer_naver.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyautogui as pag\n",
+    "import time\n",
+    "from PIL import ImageGrab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# naver page로 가는 버튼 position 위에 cursor 두고 실행\n",
+    "naver_pos = pag.position()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# alert 창 확인 버튼 position 위에 cursor 두고 실행 -> naver_button.html 버튼 누르면 50% 확률로 경고 창 뜨는데 그 위치 잡으면 됨\n",
+    "alert_ok_pos = pag.position()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# alert 창 확인 버튼 rgb 색상\n",
+    "alert_ok_rgb = (64, 138, 236)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "while True:\n",
+    "    pag.click(naver_pos)\n",
+    "    # 경고창이 뜨는데 지연 시간이 있으니까 sleep\n",
+    "    time.sleep(0.5)\n",
+    "    screen = ImageGrab.grab() # 스크린 캡쳐 기능\n",
+    "    rgb = screen.getpixel(alert_ok_pos)\n",
+    "    if rgb == alert_ok_rgb: # 경고창 발생\n",
+    "        pag.click(alert_ok_pos)\n",
+    "    else: #미발생\n",
+    "        break"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
# screen_recognizer_naver
1. html/naver_button.html 파일 실행 (50% 확률로 naver 이동 or 경고 창)
2. 네이버 이동 버튼 위치 잡음
3. alert 창 ok 위치 및 색상 잡음
4. 메인 로직을 실행 시, 경고 창이 뜨면 확인 후 다시 네이버 버튼 누르는 로직이 실행됨

# screen_recognizer_red_table
1. html/red_table.html 파일 실행 (50% 확률로 9개의 cell 중 하나가 red 로 변함)
2. cell 의 첫번째 셀의 위치 잡음
3. cell 의 첫번째 셀의 위치 잡음
4. reload 버튼의 위치 잡음
5. 메인 로직을 실행 시, cell의 첫번째부터 마지막까지 red 셀이 있나 체크후, 없으면 reload 버튼 클릭하는 로직이 실행 됨

## Todo

- [ ] 위의 화면 캡처 로직이 x와 y 에 대한 루프를 너무 많이 도는 것 같아서, 각 cell의 중간 position 만 탐색하는 로직으로 리팩토링을 했는데 잘 동작 안함 -> 이유 파악하기